### PR TITLE
Add feature to close session from outside

### DIFF
--- a/deps.ts
+++ b/deps.ts
@@ -2,3 +2,4 @@ export { decodeStream, encode } from "https://deno.land/x/msgpack@v1.4/mod.ts";
 export { deferred, delay } from "https://deno.land/x/std@0.93.0/async/mod.ts";
 export * as io from "https://deno.land/x/std@0.93.0/io/mod.ts";
 export type { Deferred } from "https://deno.land/x/std@0.93.0/async/mod.ts";
+export type { Disposable } from "https://deno.land/x/disposable@v0.2.0/mod.ts";

--- a/deps.ts
+++ b/deps.ts
@@ -1,6 +1,4 @@
 export { decodeStream, encode } from "https://deno.land/x/msgpack@v1.4/mod.ts";
-export { deferred } from "https://deno.land/x/std@0.93.0/async/deferred.ts";
+export { deferred, delay } from "https://deno.land/x/std@0.93.0/async/mod.ts";
 export * as io from "https://deno.land/x/std@0.93.0/io/mod.ts";
-export type {
-  Deferred,
-} from "https://deno.land/x/std@0.93.0/async/deferred.ts";
+export type { Deferred } from "https://deno.land/x/std@0.93.0/async/mod.ts";

--- a/deps_test.ts
+++ b/deps_test.ts
@@ -1,2 +1,3 @@
 export * from "https://deno.land/std@0.92.0/testing/asserts.ts";
 export { delay } from "https://deno.land/std@0.92.0/async/mod.ts";
+export { using } from "https://deno.land/x/disposable@v0.2.0/mod.ts";

--- a/deps_test.ts
+++ b/deps_test.ts
@@ -1,2 +1,2 @@
-export { assertEquals } from "https://deno.land/std@0.92.0/testing/asserts.ts";
+export * from "https://deno.land/std@0.92.0/testing/asserts.ts";
 export { delay } from "https://deno.land/std@0.92.0/async/mod.ts";

--- a/example/client.ts
+++ b/example/client.ts
@@ -1,4 +1,5 @@
 import { Dispatcher, Session } from "../mod.ts";
+import { using } from "../deps_test.ts";
 
 const hostname = "localhost";
 const port = 18800;
@@ -6,7 +7,7 @@ const port = 18800;
 const dispatcher: Dispatcher = {
   async helloServer(name: unknown): Promise<unknown> {
     // NOTE: 'this' is an instance of Session
-    return await this.call("hello_server", name);
+    return await this.call("helloServer", name);
   },
 
   helloClient(name: unknown): Promise<unknown> {
@@ -17,14 +18,12 @@ const dispatcher: Dispatcher = {
 try {
   console.log(`Connect to MessagePack-RPC server (${hostname}:${port})`);
   const conn = await Deno.connect({ hostname, port });
-  const client = new Session(conn, conn, dispatcher);
-  client
-    .listen()
-    .then(() => console.log("Session has disconnected"))
-    .catch((e) => console.error(e));
-  console.log(await client.call("sum", 1, 1));
-  console.log(await client.call("helloServer", "Bob"));
-  console.log(await client.call("helloClient", "Bob"));
+  await using(new Session(conn, conn, dispatcher), async (client) => {
+    console.log(await client.call("sum", 1, 1));
+    console.log(await client.call("helloServer", "Bob"));
+    console.log(await client.call("helloClient", "Bob"));
+  });
+  console.log("Session has disconnected");
   console.log(`Close connection`);
   conn.close();
 } catch (e) {

--- a/indexer.ts
+++ b/indexer.ts
@@ -1,0 +1,30 @@
+/**
+ * Indexer returns sequential index
+ */
+export class Indexer {
+  #max: number;
+  #val: number;
+
+  constructor(max?: number) {
+    if (max != null && max < 2) {
+      throw new Error(
+        `The attribute 'max' must be greater than 1 but ${max} has specified`,
+      );
+    }
+    this.#max = max ?? Number.MAX_SAFE_INTEGER;
+    this.#val = -1;
+  }
+
+  /**
+   * Increment the internal index and return it
+   *
+   * It resets the internal index if it beyonds the max.
+   */
+  next(): number {
+    if (this.#val >= this.#max) {
+      this.#val = -1;
+    }
+    this.#val += 1;
+    return this.#val;
+  }
+}

--- a/indexer_test.ts
+++ b/indexer_test.ts
@@ -1,0 +1,22 @@
+import { assertEquals, assertThrows } from "./deps_test.ts";
+import { Indexer } from "./indexer.ts";
+
+Deno.test("Indexer without 'max' works as expect", () => {
+  const indexer = new Indexer();
+  assertEquals(indexer.next(), 0);
+  assertEquals(indexer.next(), 1);
+  assertEquals(indexer.next(), 2);
+});
+
+Deno.test("Indexer with 'max' works as expect", () => {
+  const indexer = new Indexer(3);
+  assertEquals(indexer.next(), 0);
+  assertEquals(indexer.next(), 1);
+  assertEquals(indexer.next(), 2);
+  assertEquals(indexer.next(), 3);
+  assertEquals(indexer.next(), 0);
+});
+
+Deno.test("Indexer with 'max' smaller than 2 throws error", () => {
+  assertThrows(() => new Indexer(1), undefined, "must be greater than 1");
+});

--- a/response_waiter.ts
+++ b/response_waiter.ts
@@ -1,0 +1,78 @@
+import { Deferred, deferred } from "./deps.ts";
+import { MessageId, ResponseMessage } from "./message.ts";
+
+const DEFAULT_RESPONSE_TIMEOUT = 10000; // milliseconds
+
+type Waiter = {
+  timer: number;
+  response: Deferred<ResponseMessage>;
+};
+
+export class TimeoutError extends Error {
+  constructor() {
+    super("the process didn't complete in time");
+    this.name = "TimeoutError";
+  }
+}
+
+/**
+ * ResponseWaiter is for waiting a response messages for 'msgid'
+ */
+export class ResponseWaiter {
+  #waiters: Map<MessageId, Waiter>;
+  #timeout: number;
+
+  constructor(timeout = DEFAULT_RESPONSE_TIMEOUT) {
+    this.#waiters = new Map();
+    this.#timeout = timeout;
+  }
+
+  /**
+   * The number of internal waiters
+   */
+  get waiterCount(): number {
+    return this.#waiters.size;
+  }
+
+  /**
+   * Wait a response message of 'msgid'
+   */
+  wait(msgid: MessageId, timeout?: number): Promise<ResponseMessage> {
+    let response = this.#waiters.get(msgid)?.response;
+    if (!response) {
+      response = deferred();
+      const timer = setTimeout(() => {
+        const response = this.#waiters.get(msgid)?.response;
+        if (!response) {
+          return;
+        }
+        response.reject(new TimeoutError());
+        this.#waiters.delete(msgid);
+      }, timeout ?? this.#timeout);
+      this.#waiters.set(msgid, {
+        timer,
+        response,
+      });
+    }
+    return response;
+  }
+
+  /**
+   * Provide a response message
+   *
+   * It returns false if no one seems to wait the message.
+   * Otherwise it returns true.
+   */
+  provide(message: ResponseMessage): boolean {
+    const [_type, msgid, _error, _result] = message;
+    const waiter = this.#waiters.get(msgid);
+    if (!waiter) {
+      return false;
+    }
+    this.#waiters.delete(msgid);
+    const { timer, response } = waiter;
+    clearTimeout(timer);
+    response.resolve(message);
+    return true;
+  }
+}

--- a/response_waiter_test.ts
+++ b/response_waiter_test.ts
@@ -1,0 +1,40 @@
+import { assertEquals, assertThrowsAsync } from "./deps_test.ts";
+import { MessageId, ResponseMessage } from "./message.ts";
+import { ResponseWaiter, TimeoutError } from "./response_waiter.ts";
+
+Deno.test({
+  name: "ReseponseWaiter.wait() waits a response message",
+  fn: async () => {
+    const msgid: MessageId = 0;
+    const waiter = new ResponseWaiter();
+    const consumer = async () => {
+      const promise = waiter.wait(msgid);
+      assertEquals(waiter.waiterCount, 1);
+      const [_type, _msgid, _error, result] = await promise;
+      assertEquals(waiter.waiterCount, 0);
+      return result;
+    };
+    const producer = async () => {
+      await Promise.resolve();
+      const message: ResponseMessage = [1, msgid, null, "OK"];
+      waiter.provide(message);
+    };
+    const result = await Promise.all([consumer(), producer()]);
+    assertEquals(result, ["OK", undefined]);
+  },
+});
+
+Deno.test({
+  name:
+    "ReseponseWaiter.wait() throws TimeoutError and remove the internal waiter",
+  fn: async () => {
+    const msgid: MessageId = 0;
+    const waiter = new ResponseWaiter();
+    await assertThrowsAsync(async () => {
+      const promise = waiter.wait(msgid, 1);
+      assertEquals(waiter.waiterCount, 1);
+      await promise;
+    }, TimeoutError);
+    assertEquals(waiter.waiterCount, 0);
+  },
+});

--- a/session.ts
+++ b/session.ts
@@ -1,4 +1,4 @@
-import { decodeStream, encode, io } from "./deps.ts";
+import { decodeStream, Deferred, deferred, encode, io } from "./deps.ts";
 import * as message from "./message.ts";
 import { Indexer } from "./indexer.ts";
 import { ResponseWaiter } from "./response_waiter.ts";
@@ -39,6 +39,9 @@ export class Session {
   #waiter: ResponseWaiter;
   #reader: Deno.Reader & Deno.Closer;
   #writer: Deno.Writer;
+  #listener: Promise<void>;
+  #closed: boolean;
+  #closedSignal: Deferred<never>;
 
   /**
    * API name and method map which is used to dispatch API request
@@ -56,6 +59,11 @@ export class Session {
     this.#waiter = new ResponseWaiter(options.responseTimeout);
     this.#reader = reader;
     this.#writer = writer;
+    this.#closed = false;
+    this.#closedSignal = deferred();
+    this.#listener = this.listen().catch((e) => {
+      console.error(`Unexpected error occured: ${e}`);
+    });
   }
 
   private async send(data: Uint8Array): Promise<void> {
@@ -109,26 +117,32 @@ export class Session {
     }
   }
 
-  /**
-   * Listen messages and handle request/response/notification.
-   * This method must be called to start session.
-   */
-  async listen(): Promise<void> {
-    const stream = io.iter(this.#reader);
+  private async listen(): Promise<void> {
+    const iter = decodeStream(io.iter(this.#reader));
     try {
-      for await (const data of decodeStream(stream)) {
-        if (message.isRequestMessage(data)) {
-          this.handleRequest(data);
-        } else if (message.isResponseMessage(data)) {
-          this.handleResponse(data);
-        } else if (message.isNotificationMessage(data)) {
-          this.handleNotification(data);
+      while (!this.#closed) {
+        const { done, value } = await Promise.race([
+          this.#closedSignal,
+          iter.next(),
+        ]);
+        if (done) {
+          return;
+        }
+        if (message.isRequestMessage(value)) {
+          this.handleRequest(value);
+        } else if (message.isResponseMessage(value)) {
+          this.handleResponse(value);
+        } else if (message.isNotificationMessage(value)) {
+          this.handleNotification(value);
         } else {
-          console.warn(`Unexpected data received: ${data}`);
+          console.warn(`Unexpected data received: ${value}`);
           continue;
         }
       }
     } catch (e) {
+      if (e instanceof SessionClosedError) {
+        return;
+      }
       // https://github.com/denoland/deno/issues/5194#issuecomment-631987928
       if (e instanceof Deno.errors.BadResource) {
         return;
@@ -138,15 +152,33 @@ export class Session {
   }
 
   /**
+   * Close this session
+   */
+  close(): void {
+    this.#closed = true;
+    this.#closedSignal.reject(new SessionClosedError());
+  }
+
+  /**
+   * Wait until the session is closed
+   */
+  waitClosed(): Promise<void> {
+    return this.#listener;
+  }
+
+  /**
    * Call a method with params and return a Promise which resolves when a response message
    * has received and to the result value of the method.
    */
   async call(method: string, ...params: unknown[]): Promise<unknown> {
+    if (this.#closed) {
+      throw new SessionClosedError();
+    }
     const msgid = this.#indexer.next();
     const data: message.RequestMessage = [0, msgid, method, params];
-    const [_, response] = await Promise.all([
-      this.send(encode(data)),
-      this.#waiter.wait(msgid),
+    const [_, response] = await Promise.race([
+      this.#closedSignal,
+      Promise.all([this.send(encode(data)), this.#waiter.wait(msgid)]),
     ]);
     const [err, result] = response.slice(2);
     if (err) {
@@ -163,8 +195,11 @@ export class Session {
    * Notify a method with params and return a Promise which resolves when the message has sent.
    */
   async notify(method: string, ...params: unknown[]): Promise<void> {
+    if (this.#closed) {
+      throw new SessionClosedError();
+    }
     const data: message.NotificationMessage = [2, method, params];
-    await this.send(encode(data));
+    await Promise.race([this.#closedSignal, this.send(encode(data))]);
   }
 
   /**
@@ -186,5 +221,15 @@ export class Session {
       ...this.dispatcher,
       ...dispatcher,
     };
+  }
+}
+
+/**
+ * An error indicates that the session is closed
+ */
+export class SessionClosedError extends Error {
+  constructor() {
+    super("The session is closed");
+    this.name = "SessionClosedError";
   }
 }

--- a/session.ts
+++ b/session.ts
@@ -1,4 +1,11 @@
-import { decodeStream, Deferred, deferred, encode, io } from "./deps.ts";
+import {
+  decodeStream,
+  Deferred,
+  deferred,
+  Disposable,
+  encode,
+  io,
+} from "./deps.ts";
 import * as message from "./message.ts";
 import { Indexer } from "./indexer.ts";
 import { ResponseWaiter } from "./response_waiter.ts";
@@ -34,7 +41,7 @@ export type SessionOptions = {
 /**
  * MessagePack-RPC Session
  */
-export class Session {
+export class Session implements Disposable {
   #indexer: Indexer;
   #waiter: ResponseWaiter;
   #reader: Deno.Reader & Deno.Closer;
@@ -149,6 +156,10 @@ export class Session {
       }
       throw e;
     }
+  }
+
+  dispose() {
+    this.close();
   }
 
   /**

--- a/session.ts
+++ b/session.ts
@@ -27,18 +27,22 @@ export class Session {
   #replies: { [key: number]: Deferred<message.ResponseMessage> };
   #reader: Deno.Reader & Deno.Closer;
   #writer: Deno.Writer;
-  #dispatcher: Dispatcher;
+
+  /**
+   * API name and method map which is used to dispatch API request
+   */
+  dispatcher: Dispatcher;
 
   constructor(
     reader: Deno.Reader & Deno.Closer,
     writer: Deno.Writer,
     dispatcher: Dispatcher = {},
   ) {
+    this.dispatcher = dispatcher;
     this.#counter = -1;
     this.#replies = {};
     this.#reader = reader;
     this.#writer = writer;
-    this.#dispatcher = dispatcher;
   }
 
   protected getOrCreateReply(
@@ -64,13 +68,13 @@ export class Session {
     method: string,
     ...params: unknown[]
   ): Promise<unknown> {
-    if (!Object.prototype.hasOwnProperty.call(this.#dispatcher, method)) {
-      const propertyNames = Object.getOwnPropertyNames(this.#dispatcher);
+    if (!Object.prototype.hasOwnProperty.call(this.dispatcher, method)) {
+      const propertyNames = Object.getOwnPropertyNames(this.dispatcher);
       throw new Error(
         `No method '${method}' exists in ${JSON.stringify(propertyNames)}`,
       );
     }
-    return await this.#dispatcher[method].apply(this, params);
+    return await this.dispatcher[method].apply(this, params);
   }
 
   private async handleRequest(request: message.RequestMessage): Promise<void> {
@@ -160,17 +164,21 @@ export class Session {
 
   /**
    * Clear an internal dispatcher
+   *
+   * @Deprecated Use `dispatcher` directly
    */
   clearDispatcher(): void {
-    this.#dispatcher = {};
+    this.dispatcher = {};
   }
 
   /**
    * Extend an internal dispatcher
+   *
+   * @Deprecated Use `dispatcher` directly
    */
   extendDispatcher(dispatcher: Dispatcher): void {
-    this.#dispatcher = {
-      ...this.#dispatcher,
+    this.dispatcher = {
+      ...this.dispatcher,
       ...dispatcher,
     };
   }

--- a/session.ts
+++ b/session.ts
@@ -91,7 +91,7 @@ export class Session {
       return [result, error];
     })();
     const response: message.ResponseMessage = [1, msgid, error, result];
-    await io.writeAll(this.#writer, encode(response));
+    await this.send(encode(response));
   }
 
   private async handleNotification(


### PR DESCRIPTION
The session could not close (abort) after `listen()` in previous implementation.
This PR fixes it by adding the `close()` method and automatically start the session in the constructor.

To implement that, this PR applied some internal refactorings too.

For convenience, now `Session` supports `Disposable` provided by https://deno.land/x/disposable