### PR TITLE
Fix error stringify.

### DIFF
--- a/session.ts
+++ b/session.ts
@@ -108,7 +108,7 @@ export class Session implements Disposable {
         result = await this.dispatch(method, ...params);
       } catch (e) {
         // Use string representation to send the error through msgpack
-        error = e.stack ?? e.toString();
+        error = e?.stack ?? `${e}`;
       }
       return [result, error];
     })();

--- a/session_test.ts
+++ b/session_test.ts
@@ -282,3 +282,93 @@ Deno.test({
   sanitizeResources: false,
   sanitizeOps: false,
 });
+
+Deno.test({
+  name: "Session.call() throws Error if Remote throws an error",
+  fn: async () => {
+    const l2r: Uint8Array[] = []; // Local to Remote
+    const r2l: Uint8Array[] = []; // Remote to Local
+    const lr = new Reader(r2l);
+    const lw = new Writer(l2r);
+    const local = new Session(lr, lw);
+    const rr = new Reader(l2r);
+    const rw = new Writer(r2l);
+    const remote = new Session(rr, rw, {
+      say(): Promise<unknown> {
+        return Promise.reject(new Error("Panic!"));
+      },
+    });
+    await assertThrowsAsync(async () => {
+      await local.call("say");
+    }, Error, "Failed to call 'say' with []: Error: Panic!");
+    // Close
+    lr.close();
+    rr.close();
+    await Promise.all([
+      local.waitClosed(),
+      remote.waitClosed(),
+    ]);
+  },
+  sanitizeResources: false,
+  sanitizeOps: false,
+});
+
+Deno.test({
+  name: "Session.call() throws Error if Remote throws a string",
+  fn: async () => {
+    const l2r: Uint8Array[] = []; // Local to Remote
+    const r2l: Uint8Array[] = []; // Remote to Local
+    const lr = new Reader(r2l);
+    const lw = new Writer(l2r);
+    const local = new Session(lr, lw);
+    const rr = new Reader(l2r);
+    const rw = new Writer(r2l);
+    const remote = new Session(rr, rw, {
+      say(): Promise<unknown> {
+        return Promise.reject("Panic!");
+      },
+    });
+    await assertThrowsAsync(async () => {
+      await local.call("say");
+    }, Error, "Failed to call 'say' with []: Panic!");
+    // Close
+    lr.close();
+    rr.close();
+    await Promise.all([
+      local.waitClosed(),
+      remote.waitClosed(),
+    ]);
+  },
+  sanitizeResources: false,
+  sanitizeOps: false,
+});
+
+Deno.test({
+  name: "Session.call() throws Error if Remote throws null",
+  fn: async () => {
+    const l2r: Uint8Array[] = []; // Local to Remote
+    const r2l: Uint8Array[] = []; // Remote to Local
+    const lr = new Reader(r2l);
+    const lw = new Writer(l2r);
+    const local = new Session(lr, lw);
+    const rr = new Reader(l2r);
+    const rw = new Writer(r2l);
+    const remote = new Session(rr, rw, {
+      say(): Promise<unknown> {
+        return Promise.reject(null);
+      },
+    });
+    await assertThrowsAsync(async () => {
+      await local.call("say");
+    }, Error, "Failed to call 'say' with []: null");
+    // Close
+    lr.close();
+    rr.close();
+    await Promise.all([
+      local.waitClosed(),
+      remote.waitClosed(),
+    ]);
+  },
+  sanitizeResources: false,
+  sanitizeOps: false,
+});

--- a/session_test.ts
+++ b/session_test.ts
@@ -298,9 +298,13 @@ Deno.test({
         return Promise.reject(new Error("Panic!"));
       },
     });
-    await assertThrowsAsync(async () => {
-      await local.call("say");
-    }, Error, "Failed to call 'say' with []: Error: Panic!");
+    await assertThrowsAsync(
+      async () => {
+        await local.call("say");
+      },
+      Error,
+      "Failed to call 'say' with []: Error: Panic!",
+    );
     // Close
     lr.close();
     rr.close();
@@ -328,9 +332,13 @@ Deno.test({
         return Promise.reject("Panic!");
       },
     });
-    await assertThrowsAsync(async () => {
-      await local.call("say");
-    }, Error, "Failed to call 'say' with []: Panic!");
+    await assertThrowsAsync(
+      async () => {
+        await local.call("say");
+      },
+      Error,
+      "Failed to call 'say' with []: Panic!",
+    );
     // Close
     lr.close();
     rr.close();
@@ -358,9 +366,13 @@ Deno.test({
         return Promise.reject(null);
       },
     });
-    await assertThrowsAsync(async () => {
-      await local.call("say");
-    }, Error, "Failed to call 'say' with []: null");
+    await assertThrowsAsync(
+      async () => {
+        await local.call("say");
+      },
+      Error,
+      "Failed to call 'say' with []: null",
+    );
     // Close
     lr.close();
     rr.close();


### PR DESCRIPTION
If remote method throws `null` or `undefined`, an internal error occured in `handleRequest()`.